### PR TITLE
Fix EXDEV error on linux

### DIFF
--- a/src/path-replacer.coffee
+++ b/src/path-replacer.coffee
@@ -56,7 +56,13 @@ class PathReplacer extends EventEmitter
       tempStat = fs.statSync(output.path)
       origStat = fs.statSync(filePath)
       fs.chmodSync(output.path, origStat.mode) if origStat.mode != tempStat.mode
-      fs.renameSync(output.path, filePath)
+      try
+        fs.renameSync output.path, filePath
+      catch e
+        if e.code is 'EXDEV'
+          readStream = fs.createReadStream output.path
+          writeStream = fs.createWriteStream filePath
+          readStream.pipe writeStream
 
       doneCallback(result)
 


### PR DESCRIPTION
What a bug hunt!
Reproduce: Atom, Find-And-Replace, Try replacing something in your project while **not** having that file open.
#### Situation:

I'm using a fully dm-crypt + lvm encrypted system.
Additional to that my /home directory is encrypted with ecryptfs.

This results in `/` (including `/tmp`) and `/home` being on different 'devices'. Thus your call fails and nothing gets written (and replaced as consequence) if the file is not already open in buffer:

[src/path-replacer.coffee#L59](https://github.com/atom/scandal/blob/master/src/path-replacer.coffee#L59)

```
EXDEV, cross-device link not permitted '/tmp/s-114513-7666-vvnh1t' Error: EXDEV, cross-device link not permitted '/tmp/s-114513-7666-vvnh1t'
  at Object.fs.renameSync (fs.js:535:18)
  at WriteStream.<anonymous> (/home/squirtle/github/atom/node_modules/scandal/lib/path-replacer.js:104:12)
  at WriteStream.EventEmitter.emit (events.js:123:20)
  at finishMaybe (_stream_writable.js:437:14)
  at afterWrite (_stream_writable.js:317:3)
  at onwrite (_stream_writable.js:307:7)
  at WritableState.onwrite (_stream_writable.js:100:5)
  at fs.js:1664:5
  at Object.wrapper [as oncomplete] (fs.js:482:7)
```

Feel free to modify my fix to your liking. :wink:
