### PR TITLE
Remove flipNegate from minimatch options.

### DIFF
--- a/src/path-filter.coffee
+++ b/src/path-filter.coffee
@@ -5,7 +5,7 @@ path = require 'path'
 # Public: {PathFilter} makes testing for path inclusion easy.
 module.exports =
 class PathFilter
-  @MINIMATCH_OPTIONS: { matchBase: true, dot: true, flipNegate: true }
+  @MINIMATCH_OPTIONS: { matchBase: true, dot: true }
 
   @escapeRegExp: (str) ->
     str.replace(/([\/'*+?|()\[\]{}.\^$])/g, '\\$1')


### PR DESCRIPTION
This tries to address: https://github.com/atom/find-and-replace/issues/149

From what I can see the only thing stopping people from using `!**.css` in file searching on atom is that negation is explicitly turned off.

Couldn't really find a reason why it's turned off at the moment? (Maybe you can help @benogle ?)

Closes atom/find-and-replace#149
