### PR TITLE
Moved "temp" from devDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "git-utils": "^3.0.0",
     "argparse": "~0.1",
     "isbinaryfile": "~2.0.2",
-    "split": "~0.2"
+    "split": "~0.2",
+    "temp": "~0.7.0"
   },
   "devDependencies": {
     "jasmine-focused": "1.x",
@@ -39,7 +40,6 @@
     "grunt": "~0.4.1",
     "grunt-shell": "~0.2.2",
     "grunt-coffeelint": "0.0.6",
-    "temp": "~0.7.0",
     "rimraf": "~2.1.4",
     "wrench": "~1.5.4"
   }


### PR DESCRIPTION
Using scandal as a regular node library results in the following error:
```
module.js:338
    throw err;
          ^
Error: Cannot find module 'temp'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/varunramesh/projects/atomtest/node_modules/scandal/lib/path-replacer.js:10:10)
    at Object.<anonymous> (/Users/varunramesh/projects/atomtest/node_modules/scandal/lib/path-replacer.js:138:4)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
```

To fix this, I simply moved temp from devDependencies to dependencies, so that it is installed properly.