### PR TITLE
Support legit, real life negation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # scandal - Scandalous directory scanning and searching
 
 [![Build Status](https://travis-ci.org/atom/scandal.svg?branch=master)](https://travis-ci.org/atom/scandal)
+[![Deps](https://david-dm.org/atom/scandal.svg)](https://david-dm.org/atom/scandal)
 
 `scandal` provides two utilities:
 

--- a/spec/path-scanner-spec.coffee
+++ b/spec/path-scanner-spec.coffee
@@ -107,17 +107,7 @@ describe "PathScanner", ->
         runs ->
           expect(paths).not.toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
 
-      it "local inclusions override global exclusions", ->
-        scanner = new PathScanner(rootPath, inclusions: ['dir'], globalExclusions: ['dir'])
-        scanner.on('path-found', pathHandler = createPathCollector())
-        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
-
-        runs -> scanner.scan()
-        waitsFor -> finishedHandler.callCount > 0
-        runs ->
-          expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
-
-      it "lists only paths specified by file pattern", ->
+      it "excludes paths matching negated patterns in `inclusions`", ->
         scanner = new PathScanner(rootPath, inclusions: ['!*.js'])
         scanner.on('path-found', pathHandler = createPathCollector())
         scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
@@ -128,6 +118,29 @@ describe "PathScanner", ->
           expect(paths).not.toContain path.join(rootPath, 'newdir', 'deep_dir.js')
           expect(paths).not.toContain path.join(rootPath, 'sample.js')
           expect(paths).toContain path.join(rootPath, 'sample.txt')
+
+      it "local directory inclusions override global directory exclusions", ->
+        scanner = new PathScanner(rootPath, inclusions: ['dir'], globalExclusions: ['dir'])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
+
+      it "local file inclusions override global file exclusions", ->
+        scanner = new PathScanner(rootPath, inclusions: ['*.txt'], globalExclusions: ['*.txt', '.root' + path.sep])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).toContain path.join(rootPath, 'file1.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file4_noext')
+          expect(paths).not.toContain path.join(rootPath, '.root', 'file3.txt')
+          expect(paths).not.toContain path.join(rootPath, '.root', 'subdir', 'file1.txt')
 
       it "correctly matches local inclusions and exclusions", ->
         scanner = new PathScanner(rootPath, inclusions: ['file*', '!*.txt'])

--- a/spec/path-scanner-spec.coffee
+++ b/spec/path-scanner-spec.coffee
@@ -61,20 +61,6 @@ describe "PathScanner", ->
           expect(paths).toContain path.join(rootPath, 'newdir', 'deep_dir.js')
           expect(paths).toContain path.join(rootPath, 'sample.js')
 
-      it "explicit inclusions override exclusions", ->
-        scanner = new PathScanner(rootPath, inclusions: ['dir'], exclusions: ['dir'])
-        scanner.on('path-found', pathHandler = createPathCollector())
-        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
-
-        runs ->
-          scanner.scan()
-
-        waitsFor ->
-          finishedHandler.callCount > 0
-
-        runs ->
-          expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
-
       it "lists only paths specified by a deep dir", ->
         scanner = new PathScanner(rootPath, inclusions: [path.join('.root', 'subdir')+path.sep], includeHidden: true)
         scanner.on('path-found', pathHandler = createPathCollector())
@@ -87,6 +73,7 @@ describe "PathScanner", ->
           finishedHandler.callCount > 0
 
         runs ->
+          expect(paths).toContain path.join(rootPath, '.root', 'subdir', '.realhidden')
           expect(paths).toContain path.join(rootPath, '.root', 'subdir', 'file1.txt')
           expect(paths).not.toContain path.join(rootPath, '.root', 'file3.txt')
 
@@ -109,22 +96,119 @@ describe "PathScanner", ->
               expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
         )(dir)
 
-    describe "excluding file paths with the not operator", ->
+    describe "excluding file paths", ->
+      it "excludes paths matching the globalExclusions paths", ->
+        scanner = new PathScanner(rootPath, globalExclusions: ['dir'])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).not.toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
+
+      it "local inclusions override global exclusions", ->
+        scanner = new PathScanner(rootPath, inclusions: ['dir'], globalExclusions: ['dir'])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
+
       it "lists only paths specified by file pattern", ->
         scanner = new PathScanner(rootPath, inclusions: ['!*.js'])
         scanner.on('path-found', pathHandler = createPathCollector())
         scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
 
-        runs ->
-          scanner.scan()
-
-        waitsFor ->
-          finishedHandler.callCount > 0
-
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
         runs ->
           expect(paths).not.toContain path.join(rootPath, 'newdir', 'deep_dir.js')
           expect(paths).not.toContain path.join(rootPath, 'sample.js')
           expect(paths).toContain path.join(rootPath, 'sample.txt')
+
+      it "correctly matches local inclusions and exclusions", ->
+        scanner = new PathScanner(rootPath, inclusions: ['file*', '!*.txt'])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).toContain path.join(rootPath, 'file4_noext')
+          expect(paths).toContain path.join(rootPath, 'file5_not_really_image.gif')
+          expect(paths).not.toContain path.join(rootPath, 'file1.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file2.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file3.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file7_multibyte.txt')
+          expect(paths).not.toContain path.join(rootPath, 'sample.js')
+          expect(paths).not.toContain path.join(rootPath, 'sample.txt')
+
+      it "correctly matches local inclusions and global excluded files", ->
+        scanner = new PathScanner(rootPath, inclusions: ['file*'],  globalExclusions: ['*.txt'])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).toContain path.join(rootPath, 'file4_noext')
+          expect(paths).toContain path.join(rootPath, 'file5_not_really_image.gif')
+          expect(paths).not.toContain path.join(rootPath, 'file1.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file2.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file3.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file7_multibyte.txt')
+          expect(paths).not.toContain path.join(rootPath, 'sample.js')
+          expect(paths).not.toContain path.join(rootPath, 'sample.txt')
+
+      it "correctly matches local included files and global excluded dirs", ->
+        subdir = path.join('.root', 'subdir')+path.sep
+        scanner = new PathScanner(rootPath, inclusions: ['file*.txt'],  globalExclusions: [subdir])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).toContain path.join(rootPath, 'file1.txt')
+          expect(paths).toContain path.join(rootPath, 'file2.txt')
+          expect(paths).toContain path.join(rootPath, 'file7_multibyte.txt')
+          expect(paths).not.toContain path.join(rootPath, 'file4_noext')
+          expect(paths).not.toContain path.join(rootPath, 'file5_not_really_image.gif')
+          expect(paths).not.toContain path.join(rootPath, '.root', 'subdir', 'file1.txt')
+          expect(paths).not.toContain path.join(rootPath, 'sample.js')
+          expect(paths).not.toContain path.join(rootPath, 'sample.txt')
+
+      it "correctly matches local included files and global excluded dirs", ->
+        subdir = path.join('.root', 'subdir')+path.sep
+        scanner = new PathScanner(rootPath, inclusions: [subdir],  globalExclusions: [subdir, '*.txt'], includeHidden: true)
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths.length).toBe 1
+          expect(paths).toContain path.join(rootPath, '.root', 'subdir', '.realhidden')
+          expect(paths).not.toContain path.join(rootPath, '.root', 'subdir', 'file1.txt')
+
+      dirs = ['!dir', "!dir#{path.sep}", "!dir#{path.sep}*", "!dir#{path.sep}**"]
+      for dir in dirs
+        ((dir) ->
+          it "lists only paths specified in #{dir}", ->
+            scanner = new PathScanner(rootPath, inclusions: [dir])
+            scanner.on('path-found', pathHandler = createPathCollector())
+            scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+            runs -> scanner.scan()
+            waitsFor -> finishedHandler.callCount > 0
+            runs ->
+              expect(paths.length).toBeGreaterThan 1
+              expect(paths).toContain path.join(rootPath, 'sample.txt')
+              expect(paths).not.toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
+        )(dir)
 
   describe "with a git repo", ->
     beforeEach ->

--- a/src/path-filter.coffee
+++ b/src/path-filter.coffee
@@ -20,6 +20,8 @@ class PathFilter
   #      additions: `['dirname']` and `['dirname/']` will match all paths in
   #      directory dirname.
   #   * `exclusions` {Array} of patterns to exclude. Same matcher as inclusions.
+  #   * `globalExclusions` {Array} of patterns to exclude. These patterns can be
+  #     overridden by `inclusions`. Same matcher as inclusions.
   #   * `includeHidden` {Boolean} default false; true includes hidden files
   constructor: (rootPath, options={}) ->
     {includeHidden, excludeVcsIgnores} = options

--- a/src/path-filter.coffee
+++ b/src/path-filter.coffee
@@ -57,7 +57,7 @@ class PathFilter
   isDirectoryAccepted: (filepath) ->
     return false if @isPathExcluded('directory', filepath) is true
 
-    # An matching explicit local inclusion will override the global exclusions
+    # A matching explicit local inclusion will override the global exclusions
     # Other than this, the logic is the same between file and directory matching.
     return true if @inclusions['directory']?.length && @isPathIncluded('directory', filepath)
 


### PR DESCRIPTION
This is the path to finishing https://github.com/atom/find-and-replace/issues/149 and does a couple things:

* Supports more than one negated pattern in `inclusions`. It will move negated patterns to the `exclusions` list.
* It adds a new exclusions list called `globalExclusions`. Global exclusions are the `core.ignoredNames` in atom. These patterns can be overridden by the `inclusions`.

### Behavior

There are semi-complicated interactions with the `inclusions`, `exclusions`, and `globalExclusions` that need to work well. These are all supported by this PR. Consider the following tree:

```
/src/main.py
/src/main.pyc
/src/README.md
/test/test-main.py
/test/test-main.pyc
/vendor/somelib/somelib.py
/vendor/somelib/somelib.pyc
/vendor/somelib/README.md
```

Let's pretend we have `ignoredNames` set to `vendor/, *.pyc`, which means:

```
globalExclusions: ['vendor/', '*.pyc']
```

Without `inclusions` or `exclusions` set, it will search:

```
inclusions: []
exclusions: []
globalExclusions: ['vendor/', '*.pyc']

Paths Scanned:
/src/main.py
/src/README.md
/test/test-main.py
```

But we're totally over markdown files and dont want to search them, so we specify a negation of `!*.md`. This negation makes it into the `exclusions` list

```
inclusions: []
exclusions: ['*.md']
globalExclusions: ['vendor/', '*.pyc']

Paths Scanned:
/src/main.py
/test/test-main.py
```

And maybe we want to search `vendor/`. In this case, the `vendor` inclusion needs to override the `vendor/` in `globalExclusions`. Otherwise, no results will show, and people will be confused. Also, we expect to still ignore `*.pyc` files.

```
inclusions: ['vendor']
exclusions: ['*.md']
globalExclusions: ['vendor/', '*.pyc']

Paths Scanned:
/src/main.py
/test/test-main.py
/vendor/somelib/somelib.py
```

Along the same lines, we might want to search `pyc` files. In this case, we still expect the `vendor` directory to be ignored.

```
inclusions: ['*.pyc']
exclusions: ['*.md']
globalExclusions: ['vendor/', '*.pyc']

Paths Scanned:
/src/main.py
/src/main.pyc
/test/test-main.py
/test/test-main.pyc
```

And finally, maybe we dont want to search in the `tests` directory, so lets add a new negation for that. At this point the `paths` input in find and replace would look like: `vendor, !*.md, !test/`

```
inclusions: ['vendor']
exclusions: ['*.md', 'test/']
globalExclusions: ['vendor/', '*.pyc']

Paths Scanned:
/src/main.py
/vendor/somelib/somelib.py
```
