### PR TITLE
:art: lazy load git-utils since this is the only usage

### DIFF
--- a/src/path-filter.coffee
+++ b/src/path-filter.coffee
@@ -1,5 +1,4 @@
 {Minimatch} = require 'minimatch'
-GitUtils = require 'git-utils'
 path = require 'path'
 fs = require 'fs'
 
@@ -32,7 +31,7 @@ class PathFilter
     @exclusions = @createMatchers(exclusions, {deepMatch: false})
     @globalExclusions = @createMatchers(globalExclusions, {deepMatch: false, disallowDuplicatesFrom: @inclusions})
 
-    @repo = GitUtils.open(@rootPath) if excludeVcsIgnores
+    @repo = require('git-utils').open(@rootPath) if excludeVcsIgnores
 
     @excludeHidden() if includeHidden != true
 


### PR DESCRIPTION
It is very unlikely that will give any performance gain. The main motivation I have is to use this package as a fork where I simply remove `git-utils` as a package dependency (as that needed a working node-gyp toolchain) and use this package as is without triggering the git-utils code path. 

I would completely understand if you want to disregard this PR :rose: :+1: 