### PR TITLE
Don't override global exclusions with directory inclusions...

### DIFF
--- a/spec/fixtures/many-files/newdir/seconddir/very_deep_dir.js
+++ b/spec/fixtures/many-files/newdir/seconddir/very_deep_dir.js
@@ -1,0 +1,1 @@
+text two directories deep

--- a/spec/path-scanner-spec.coffee
+++ b/spec/path-scanner-spec.coffee
@@ -126,7 +126,7 @@ describe "PathScanner", ->
           expect(paths).not.toContain path.join(rootPath, 'sample.js')
           expect(paths).toContain path.join(rootPath, 'sample.txt')
 
-      it "local directory inclusions override global directory exclusions", ->
+      it "allows a local directory inclusion to override a matching global exclusion", ->
         scanner = new PathScanner(rootPath, inclusions: ['dir'], globalExclusions: ['dir'])
         scanner.on('path-found', pathHandler = createPathCollector())
         scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
@@ -136,7 +136,7 @@ describe "PathScanner", ->
         runs ->
           expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
 
-      it "local directory inclusions don't override global subdirectory exclusions", ->
+      it "doesn't allow a local directory inclusion to override a global exclusion of a subdirectory", ->
         scanner = new PathScanner(rootPath, inclusions: ['newdir'], globalExclusions: ['seconddir'])
         scanner.on('path-found', pathHandler = createPathCollector())
         scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
@@ -147,7 +147,7 @@ describe "PathScanner", ->
           expect(paths).toContain path.join(rootPath, 'newdir', 'deep_dir.js')
           expect(paths).not.toContain path.join(rootPath, 'newdir', 'seconddir', 'very_deep_dir.js')
 
-      it "local file inclusions override global file exclusions", ->
+      it "allows a local file inclusion to override a global file exclusion", ->
         scanner = new PathScanner(rootPath, inclusions: ['*.txt'], globalExclusions: ['*.txt', '.root' + path.sep])
         scanner.on('path-found', pathHandler = createPathCollector())
         scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())

--- a/spec/path-scanner-spec.coffee
+++ b/spec/path-scanner-spec.coffee
@@ -147,6 +147,18 @@ describe "PathScanner", ->
           expect(paths).toContain path.join(rootPath, 'newdir', 'deep_dir.js')
           expect(paths).not.toContain path.join(rootPath, 'newdir', 'seconddir', 'very_deep_dir.js')
 
+      it "allows a local inclusion of a subdirectory to override a global directory exclusion", ->
+        scanner = new PathScanner(rootPath, inclusions: ['newdir/seconddir'], globalExclusions: ['newdir'])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths.length).toBe 1
+          expect(paths).not.toContain path.join(rootPath, 'newdir', 'deep_dir.js')
+          expect(paths).toContain path.join(rootPath, 'newdir', 'seconddir', 'very_deep_dir.js')
+
       it "allows a local file inclusion to override a global file exclusion", ->
         scanner = new PathScanner(rootPath, inclusions: ['*.txt'], globalExclusions: ['*.txt', '.root' + path.sep])
         scanner.on('path-found', pathHandler = createPathCollector())

--- a/spec/path-scanner-spec.coffee
+++ b/spec/path-scanner-spec.coffee
@@ -29,9 +29,9 @@ describe "PathScanner", ->
       runs ->
         # symlink-to-file1.txt is a file on windows
         if process.platform is 'win32'
-          expect(paths.length).toBe 18
+          expect(paths.length).toBe 19
         else
-          expect(paths.length).toBe 17
+          expect(paths.length).toBe 18
 
         expect(paths).toContain path.join(rootPath, 'file1.txt')
         expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
@@ -47,7 +47,7 @@ describe "PathScanner", ->
         runs -> scanner.scan()
         waitsFor -> finishedHandler.callCount > 0
         runs ->
-          expect(paths.length).toBe 4
+          expect(paths.length).toBe 5
           expect(paths).toContain path.join(rootPath, 'newdir', 'deep_dir.js')
           expect(paths).toContain path.join(rootPath, 'sample.js')
 
@@ -135,6 +135,17 @@ describe "PathScanner", ->
         waitsFor -> finishedHandler.callCount > 0
         runs ->
           expect(paths).toContain path.join(rootPath, 'dir', 'file7_ignorable.rb')
+
+      it "local directory inclusions don't override global subdirectory exclusions", ->
+        scanner = new PathScanner(rootPath, inclusions: ['newdir'], globalExclusions: ['seconddir'])
+        scanner.on('path-found', pathHandler = createPathCollector())
+        scanner.on('finished-scanning', finishedHandler = jasmine.createSpy())
+
+        runs -> scanner.scan()
+        waitsFor -> finishedHandler.callCount > 0
+        runs ->
+          expect(paths).toContain path.join(rootPath, 'newdir', 'deep_dir.js')
+          expect(paths).not.toContain path.join(rootPath, 'newdir', 'seconddir', 'very_deep_dir.js')
 
       it "local file inclusions override global file exclusions", ->
         scanner = new PathScanner(rootPath, inclusions: ['*.txt'], globalExclusions: ['*.txt', '.root' + path.sep])

--- a/src/path-filter.coffee
+++ b/src/path-filter.coffee
@@ -57,14 +57,13 @@ class PathFilter
   # Returns {Boolean} true if the directory is accepted
   isDirectoryAccepted: (filepath) ->
     return false if @isPathExcluded('directory', filepath) is true
+    return false if @isPathGloballyExcluded('directory', filepath) is true
 
-    # A matching explicit local inclusion will override the global exclusions
+    # A matching explicit local inclusion will override any Git exclusions
     # Other than this, the logic is the same between file and directory matching.
     return true if @inclusions['directory']?.length && @isPathIncluded('directory', filepath)
 
-    @isPathIncluded('directory', filepath) &&
-    !@isPathGloballyExcluded('directory', filepath) &&
-    !@isPathExcludedByGit(filepath)
+    @isPathIncluded('directory', filepath) && !@isPathExcludedByGit(filepath)
 
   isPathAccepted: (fileOrDirectory, filepath) ->
     !@isPathExcluded(fileOrDirectory, filepath) &&

--- a/src/path-filter.coffee
+++ b/src/path-filter.coffee
@@ -22,7 +22,8 @@ class PathFilter
   #      directory dirname.
   #   * `exclusions` {Array} of patterns to exclude. Same matcher as inclusions.
   #   * `globalExclusions` {Array} of patterns to exclude. These patterns can be
-  #     overridden by `inclusions`. Same matcher as inclusions.
+  #      overridden by `inclusions` if the inclusion is a duplicate or a
+  #      subdirectory of the exclusion. Same matcher as inclusions.
   #   * `includeHidden` {Boolean} default false; true includes hidden files
   constructor: (@rootPath, options={}) ->
     {includeHidden, excludeVcsIgnores} = options
@@ -47,60 +48,104 @@ class PathFilter
   #
   # Returns {Boolean} true if the file is accepted
   isFileAccepted: (filepath) ->
-    @isDirectoryAccepted(filepath) and @isPathAccepted('file', filepath)
+    @isDirectoryAccepted(filepath) and
+      !@isPathExcluded('file', filepath) and
+      @isPathIncluded('file', filepath) and
+      !@isPathGloballyExcluded('file', filepath)
 
   # Public: Test if the `filepath` is accepted as a directory based on the
   # constructing options.
   #
-  # * `filepath` {String} path to a directory. File should be a directory and should exist
+  # * `filepath` {String} path to a directory. File should be a file or directory
+  #   and should exist
   #
   # Returns {Boolean} true if the directory is accepted
   isDirectoryAccepted: (filepath) ->
     return false if @isPathExcluded('directory', filepath) is true
-    return false if @isPathGloballyExcluded('directory', filepath) is true
+
+    matchingInclusions = @getMatchingItems(@inclusions['directory'], filepath)
+
+    # Matching global exclusions will be overriden if there is a matching
+    # inclusion for a subdirectory of the exclusion.
+    # For example: if node_modules is globally excluded but mode_modules/foo is
+    # explicitly included, then the global exclusion is overridden for
+    # node_modules/foo
+    matchingGlobalExclusions = @overrideGlobalExclusions(
+      @getMatchingItems(@globalExclusions['directory'], filepath), matchingInclusions)
+
+    # Don't accept if there's a matching global exclusion
+    return false if matchingGlobalExclusions.length
 
     # A matching explicit local inclusion will override any Git exclusions
-    # Other than this, the logic is the same between file and directory matching.
-    return true if @inclusions['directory']?.length && @isPathIncluded('directory', filepath)
+    return true if matchingInclusions.length
 
-    @isPathIncluded('directory', filepath) && !@isPathExcludedByGit(filepath)
+    # Don't accept if there Were inclusions specified that didn't match
+    return false if @inclusions['directory']?.length
 
-  isPathAccepted: (fileOrDirectory, filepath) ->
-    !@isPathExcluded(fileOrDirectory, filepath) &&
-    @isPathIncluded(fileOrDirectory, filepath) &&
-    !@isPathGloballyExcluded(fileOrDirectory, filepath)
+    # Finally, check for Git exclusions
+    !@isPathExcludedByGit(filepath)
+
 
   ###
   Section: Private Methods
   ###
 
   isPathIncluded: (fileOrDirectory, filepath) ->
-    inclusions = @inclusions[fileOrDirectory]
-    return true unless inclusions?.length
-
-    index = inclusions.length
-    while index--
-      return true if inclusions[index].match(filepath)
-    return false
+    return true unless @inclusions[fileOrDirectory]?.length
+    return @getMatchingItems(@inclusions[fileOrDirectory], filepath,
+                             stopAfterFirst=true)?.length > 0
 
   isPathExcluded: (fileOrDirectory, filepath) ->
-    exclusions = @exclusions[fileOrDirectory]
-    return false unless exclusions?.length
-
-    index = exclusions.length
-    while index--
-      return true if (exclusions[index].match(filepath))
-    return false
+    return @getMatchingItems(@exclusions[fileOrDirectory], filepath,
+                             stopAfterFirst=true)?.length > 0
 
   isPathGloballyExcluded: (fileOrDirectory, filepath) ->
-    exclusions = @globalExclusions[fileOrDirectory]
-    index = exclusions.length
+    return @getMatchingItems(@globalExclusions[fileOrDirectory], filepath,
+                             stopAfterFirst=true)?.length > 0
+
+  # Given an array of `matchers`, return an array containing only those that
+  # match `filepath`.
+  getMatchingItems: (matchers, filepath, stopAfterFirst=false) ->
+    index = matchers.length
+    result = []
     while index--
-      return true if (exclusions[index].match(filepath))
-    return false
+      if matchers[index].match(filepath)
+        result.push(matchers[index])
+        return result if stopAfterFirst
+    return result
 
   isPathExcludedByGit: (filepath) ->
     @repo?.isIgnored(@repo.relativize(filepath))
+
+  # Given an array of `globalExclusions`, filter out any which have an
+  # `inclusion` defined for a subdirectory
+  overrideGlobalExclusions: (globalExclusions, inclusions) ->
+    result = []
+    exclusionIndex = globalExclusions.length
+    while exclusionIndex--
+      inclusionIndex = inclusions.length
+      requiresOverride = false
+
+      # Check if an inclusion is specified for a subdirectory of this globalExclusion
+      while inclusionIndex--
+        if @isSubpathMatcher(globalExclusions[exclusionIndex], inclusions[inclusionIndex])
+          requiresOverride = true
+
+      result.push(globalExclusions[exclusionIndex]) if !requiresOverride
+    return result
+
+  # Returns true if the `child` matcher is a subdirectory of the `parent` matcher
+  isSubpathMatcher: (parent, child) ->
+    # Strip off trailing wildcards from the parent pattern
+    parentPattern = parent.pattern
+    directoryPattern = ///
+      #{'\\'+path.sep}\*$|   # Matcher ends with a separator followed by *
+      #{'\\'+path.sep}\*\*$  # Matcher ends with a separator followed by **
+    ///
+    matchIndex = parentPattern.search(directoryPattern)
+    parentPattern = parentPattern.slice(0, matchIndex) if matchIndex > -1
+
+    return child.pattern.substr(0, parentPattern.length) == parentPattern
 
   sanitizePaths: (options) ->
     return options unless options.inclusions?.length


### PR DESCRIPTION
unless they match exactly.

In particular, if a subdirectory of an inclusion is globally excluded,
the exclusion should not be overridden.

The "exact match" case seems to be already handled by `disallowDuplicatesFrom: @inclusions` when the `globalExclusions` matcher is created.

Fixes the `core.ignoredNames` part of atom/atom#12389.
This was originally reported in atom/find-and-replace#621.

There may be a similar issue with Git-ignored directories, but I'm not sure how or if that should be fixed.