### PR TITLE
Handle errors correctly in ChunkedLineReader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,14 @@ notifications:
     on_failure: change
 
 node_js:
-  - 5
+  - 4
+
+sudo: false
+
+env: NODE_VERSION=4.4.7 CC=clang CXX=clang++ npm_config_clang=1
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - clang-3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ notifications:
     on_failure: change
 
 node_js:
-  - 0.10
+  - 5

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "temp": "^0.8.3"
   },
   "devDependencies": {
+    "coffeelint": "^1.15.7",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-coffeelint": "0.0.13",

--- a/spec/chunked-line-reader-spec.coffee
+++ b/spec/chunked-line-reader-spec.coffee
@@ -14,18 +14,20 @@ describe "ChunkedLineReader", ->
     ChunkedLineReader.CHUNK_SIZE = chunkSize
     ChunkedLineReader.chunkedBuffer = null
 
-  it "throws an error when the file does not exist", ->
+  it "emits an error when the file does not exist", ->
     dataHandler = jasmine.createSpy('data handler')
 
     reader = new ChunkedLineReader('/this-does-not-exist.js')
     reader.on 'end', endHandler = jasmine.createSpy('end handler')
+    reader.on 'error', errorHandler = jasmine.createSpy('error handler')
 
-    expect( -> reader.on 'data', dataHandler ).toThrow()
+    reader.on 'data', dataHandler
 
     waitsFor ->
-      endHandler.callCount > 0
+      errorHandler.callCount > 0
 
     runs ->
+      expect(errorHandler).toHaveBeenCalled()
       expect(endHandler).toHaveBeenCalled()
       expect(dataHandler).not.toHaveBeenCalled()
 

--- a/src/chunked-line-reader.coffee
+++ b/src/chunked-line-reader.coffee
@@ -80,6 +80,9 @@ class ChunkedLineReader extends Readable
 
       @push(remainder) if remainder
 
+    catch error
+      @emit('error', error)
+
     finally
       fs.closeSync(fd) if fd?
       @push(null)

--- a/src/path-replacer.coffee
+++ b/src/path-replacer.coffee
@@ -73,8 +73,8 @@ class PathReplacer extends EventEmitter
         @emit('file-error', error)
         doneCallback(null, error)
 
-    try
-      reader.pipe(replacer).pipe(output)
-    catch error
+    reader.on 'error', (error) =>
       @emit('file-error', error)
       doneCallback(null, error)
+
+    reader.pipe(replacer).pipe(output)

--- a/src/path-searcher.coffee
+++ b/src/path-searcher.coffee
@@ -146,6 +146,10 @@ class PathSearcher extends EventEmitter
     reader = new ChunkedLineReader(filePath)
     error = null
 
+    reader.on 'error', (e) =>
+      error = e
+      @emit('file-error', error)
+
     reader.on 'end', =>
       if matches?.length
         output = {filePath, matches}
@@ -154,18 +158,15 @@ class PathSearcher extends EventEmitter
         @emit('results-not-found', filePath)
       doneCallback(output, error)
 
-    try
-      reader.on 'data', (chunk) =>
-        lines = chunk.toString().replace(TRAILING_LINE_END_REGEX, '').split(LINE_END_REGEX)
-        for line in lines
-          lineMatches = @searchLine(regex, line, lineNumber++)
+    reader.on 'data', (chunk) =>
+      lines = chunk.toString().replace(TRAILING_LINE_END_REGEX, '').split(LINE_END_REGEX)
+      for line in lines
+        lineMatches = @searchLine(regex, line, lineNumber++)
 
-          if lineMatches?
-            matches ?= []
-            matches.push(match) for match in lineMatches
-    catch e
-      error = e
-      @emit('file-error', e)
+        if lineMatches?
+          matches ?= []
+          matches.push(match) for match in lineMatches
+
 
     return
 


### PR DESCRIPTION
When there is an error reading from a Node `ReadStream`, we are supposed to emit an error event rather than throwing. In versions of Node > 0.10 when this code was originally written, the existing error handling breaks down due to a previously synchronous call to `_read` being moved behind a `nextTick`. Emitting the event instead of throwing works around this and gets our tests green on modern versions of Node.