### PR TITLE
Fix excludeVcsIgnore when working in subdirs

### DIFF
--- a/spec/fixtures/git/src/.gitignore
+++ b/spec/fixtures/git/src/.gitignore
@@ -1,0 +1,2 @@
+ignored.txt
+node_modules

--- a/spec/fixtures/git/src/file.txt
+++ b/spec/fixtures/git/src/file.txt
@@ -1,0 +1,1 @@
+a file in a subdirectory

--- a/spec/fixtures/git/src/node_modules/pkg/sample.js
+++ b/spec/fixtures/git/src/node_modules/pkg/sample.js
@@ -1,0 +1,13 @@
+var quicksort = function () {
+  var sort = function(items) {
+    if (items.length <= 1) return items;
+    var pivot = items.shift(), current, left = [], right = [];
+    while(items.length > 0) {
+      current = items.shift();
+      current < pivot ? left.push(current) : right.push(current);
+    }
+    return sort(left).concat(pivot).concat(sort(right));
+  };
+
+  return sort(Array.apply(this, arguments));
+};

--- a/spec/fixtures/git/src/other.txt
+++ b/spec/fixtures/git/src/other.txt
@@ -1,0 +1,1 @@
+another file in a subdirectory

--- a/src/path-filter.coffee
+++ b/src/path-filter.coffee
@@ -115,7 +115,7 @@ class PathFilter
     return result
 
   isPathExcludedByGit: (filepath) ->
-    @repo?.isIgnored(@repo.relativize(filepath))
+    @repo?.isIgnored(@repo.relativize(path.join(@rootPath, filepath)))
 
   # Given an array of `globalExclusions`, filter out any which have an
   # `inclusion` defined for a subdirectory


### PR DESCRIPTION
Since I switched to atom a few weeks ago, I've found that our project's `node_modules` and other `.gitignore`d paths are always searched, despite having `excludeVcsIgnoredPaths` set to `true` in my config. I have to remember to add `!node_modules, !dist, ...`, etc. to the file directory pattern.

I dug into this and found that if your atom project is rooted in a directory other than the root of your git working directory (as is the case when you're working on a single project in a monorepo like ours) `PathFilter`s `isPathIsExcludedByGit` will always return false. (because, in fact, it doesn't recognize the relativized path passed in by [`PathScanner`](https://github.com/artgillespie/scandal/blob/fix-exclude-vcs-ignore-in-subdirs/src/path-scanner.coffee#L91-L92)

See related issue in atom core: https://github.com/atom/atom/issues/9175

