### PR TITLE
add context lines to matches

### DIFF
--- a/spec/chunked-line-reader-spec.coffee
+++ b/spec/chunked-line-reader-spec.coffee
@@ -47,7 +47,7 @@ describe "ChunkedLineReader", ->
     runs ->
       sample = [
         'var quicksort = function () {'
-        '  var sort = function(items) {'
+        '  var sort = function(items) {  # followed by a pretty long comment which is used to check the maxLineLength feature'
         '    if (items.length <= 1) return items;'
         '    var pivot = items.shift(), current, left = [], right = [];'
         '    while(items.length > 0) {'

--- a/spec/fixtures/many-files/sample.js
+++ b/spec/fixtures/many-files/sample.js
@@ -1,5 +1,5 @@
 var quicksort = function () {
-  var sort = function(items) {
+  var sort = function(items) {  # followed by a pretty long comment which is used to check the maxLineLength feature
     if (items.length <= 1) return items;
     var pivot = items.shift(), current, left = [], right = [];
     while(items.length > 0) {

--- a/spec/path-replacer-spec.coffee
+++ b/spec/path-replacer-spec.coffee
@@ -58,7 +58,7 @@ describe "PathReplacer", ->
 
         replacedContent = '''
           var quicksort = function () {
-            var sort = function(omgwow) {
+            var sort = function(omgwow) {  # followed by a pretty long comment which is used to check the maxLineLength feature
               if (omgwow.length <= 1) return omgwow;
               var pivot = omgwow.shift(), current, left = [], right = [];
               while(omgwow.length > 0) {

--- a/src/path-searcher.coffee
+++ b/src/path-searcher.coffee
@@ -5,6 +5,8 @@ ChunkedExecutor = require("./chunked-executor")
 ChunkedLineReader = require("./chunked-line-reader")
 
 MAX_LINE_LENGTH = 100
+LINE_COUNT_BEFORE = 0
+LINE_COUNT_AFTER = 0
 WORD_BREAK_REGEX = /[ \r\n\t;:?=&\/]/
 LINE_END_REGEX = /\r\n|\n|\r/
 TRAILING_LINE_END_REGEX = /\r?\n?$/
@@ -22,7 +24,7 @@ TRAILING_LINE_END_REGEX = /\r?\n?$/
 #
 # ```coffee
 # {PathSearcher} = require 'scandal'
-# searcher = new PathSearcher()
+# searcher = new PathSearcher({lineCountBefore: 2, lineCountAfter: 3})
 #
 # # You can subscribe to a `results-found` event
 # searcher.on 'results-found', (result) ->
@@ -47,7 +49,9 @@ TRAILING_LINE_END_REGEX = /\r?\n?$/
 #     "matchText": "Text",
 #     "lineText": "Text in this file!",
 #     "lineTextOffset": 0,
-#     "range": [[9, 0], [9, 4]]
+#     "range": [[9, 0], [9, 4]],
+#     "linesBefore": ["line #8", "line #9"],
+#     "linesAfter": ["line #11", "line #12", "line #13"]
 #   }]
 # }
 # ```
@@ -66,7 +70,9 @@ TRAILING_LINE_END_REGEX = /\r?\n?$/
 #       "matchText": "Text",
 #       "lineText": "Text in this file!",
 #       "lineTextOffset": 0,
-#       "range": [[9, 0], [9, 4]]
+#       "range": [[9, 0], [9, 4]],
+#       "linesBefore": ["line #8", "line #9"],
+#       "linesAfter": ["line #11", "line #12", "line #13"]
 #     }]
 #   }
 #   ```
@@ -91,10 +97,18 @@ class PathSearcher extends EventEmitter
   # * `options` {Object}
   #   * `maxLineLength` {Number} default `100`; The max length of the `lineText`
   #      component in a results object. `lineText` is the context around the matched text.
+  #   * `lineCountBefore` {Number} default `0`; The number of lines before the
+  #      matched line to include in the results object. Each line is subject
+  #      to the `maxLineLength` limit.
+  #   * `lineCountAfter` {Number} default `0`; The number of lines after the
+  #      matched line to include in the results object. Each line is subject
+  #      to the `maxLineLength` limit.
   #   * `wordBreakRegex` {RegExp} default `/[ \r\n\t;:?=&\/]/`;
   #      Used to break on a word when finding the context for a match.
-  constructor: ({@maxLineLength, @wordBreakRegex}={}) ->
+  constructor: ({@maxLineLength, @lineCountBefore, @lineCountAfter, @wordBreakRegex}={}) ->
     @maxLineLength ?= MAX_LINE_LENGTH
+    @lineCountBefore ?= LINE_COUNT_BEFORE
+    @lineCountAfter ?= LINE_COUNT_AFTER
     @wordBreakRegex ?= WORD_BREAK_REGEX
 
   ###
@@ -150,6 +164,11 @@ class PathSearcher extends EventEmitter
       error = e
       @emit('file-error', error)
 
+    # remember @lineCountBefore recent lines already truncated to @maxLineLength
+    recentLines = []
+    # remember recent matches from the last @lineCountAfter lines
+    recentMatches = []
+
     reader.on 'end', =>
       if matches?.length
         output = {filePath, matches}
@@ -161,12 +180,32 @@ class PathSearcher extends EventEmitter
     reader.on 'data', (chunk) =>
       lines = chunk.toString().replace(TRAILING_LINE_END_REGEX, '').split(LINE_END_REGEX)
       for line in lines
+        # update linesAfter of recent matches
+        if @lineCountAfter > 0
+          for match in recentMatches
+            match.linesAfter.push(line.substr(0, @maxLineLength))
+
         lineMatches = @searchLine(regex, line, lineNumber++)
 
         if lineMatches?
           matches ?= []
-          matches.push(match) for match in lineMatches
+          for match in lineMatches
+            match.linesBefore = recentLines.slice(recentLines.length - @lineCountBefore)
+            match.linesAfter = []
+            matches.push(match)
 
+        # remove obsolete lines from recentLines
+        if @lineCountBefore > 0
+          while recentLines.length > @lineCountBefore
+            recentLines.shift()
+          recentLines.push(line.substr(0, @maxLineLength))
+
+        # remove obsolete matches from recentMatches
+        if @lineCountAfter > 0
+          while recentMatches.length > 0 and recentMatches[0].range[0][0] < lineNumber - @lineCountAfter
+            recentMatches.shift()
+          if lineMatches?
+            recentMatches.push(match) for match in lineMatches
 
     return
 


### PR DESCRIPTION
This adds two option to the `PathSearcher`: `lineCountBefore` and `lineCountAfter` which both default to `0`. The returned matches contain the two additional fields `linesTextBefore' and 'linesTextAfter' which each contains an array of lines (each truncated to the maxLineLength limit).

E.g. if the search was done with `lineCountBefore: 2` and `lineCountAfter: 3` a match in line `N` would contain `linesTextBefore` with `['line N-2', 'line N-1']` and `linesTextAfter` with `['line N+1', 'line N+2', 'line N+3']`.