### PR TITLE
Update minimatch to v3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "argparse": "^1.0.2",
     "git-utils": "^5.0.0",
     "isbinaryfile": "^2.0.4",
-    "minimatch": "^2.0.9",
+    "minimatch": "^3.0.4",
     "split": "^1.0.0",
     "temp": "^0.8.3"
   },


### PR DESCRIPTION
Fixes [Node Security advisory #118](https://nodesecurity.io/advisories/118), therefore getting rid of the “dependencies insecure” badge in the readme.