### PR TITLE
Export PathFilter

### DIFF
--- a/src/scandal.coffee
+++ b/src/scandal.coffee
@@ -2,6 +2,7 @@
 PathSearcher = require './path-searcher'
 PathScanner = require './path-scanner'
 PathReplacer = require './path-replacer'
+PathFilter = require './path-filter'
 path = require "path"
 
 SingleProcess = require('./single-process-search')
@@ -37,4 +38,4 @@ main = ->
   else
     singleProcessScanMain(options)
 
-module.exports = {main, search, replace, PathSearcher, PathScanner, PathReplacer}
+module.exports = {main, search, replace, PathSearcher, PathScanner, PathReplacer, PathFilter}


### PR DESCRIPTION
Hi! The README [mentions](https://github.com/atom/scandal/tree/master@%7B2020-05-01%7D#pathfilter) that PathFilter is available as an export, but it didn't appear to be exported. 🙂 PathFilter would be a very useful utility to have access to in my particular use case.