### PR TITLE
Update git-utils to version 2.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -294,12 +294,12 @@
       "dev": true
     },
     "git-utils": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.0.tgz",
-      "integrity": "sha512-eOBROJEQPQtkqzZe5V0m43YhKjhmzXTqULxlhoaCwORClnHtZIwkJQTS6THXRbvIqDq/cRHta85IqTbVzdvB5g==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.2.tgz",
+      "integrity": "sha512-3pen//xGs5ZJiXejUbx79FyRR58J6DgI7tL9Mc7YQeuF5ENXf/7k0K2M8h4JBlTKZcxxCr8MGA1Xcg4O4l/YjA==",
       "requires": {
         "fs-plus": "^3.0.0",
-        "nan": "^2.0.0"
+        "nan": "^2.14.0"
       }
     },
     "glob": {
@@ -753,9 +753,9 @@
       }
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nopt": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "http://atom.github.io/scandal",
   "dependencies": {
     "argparse": "^1.0.2",
-    "git-utils": "^5.6.0",
+    "git-utils": "5.6.2",
     "isbinaryfile": "^2.0.4",
     "minimatch": "^2.0.9",
     "split": "^1.0.0",


### PR DESCRIPTION
This change is required to fix Travis CI for the project

Version 2.6.2 is used by atom core.
This fixes build with up-to-date node.js